### PR TITLE
Add license refrence to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,3 +27,8 @@ OSSMediator is compatible with only Unix/Linux system.
     ├── OpenNMSPlugin               # Source files
     ├── ElasticsearchPlugin         # Source files
     └── README.md  
+
+
+## License
+
+This project is licensed under the BSD-3-Clause license - see the [LICENSE](https://github.com/nokia/OSSMediator/blob/master/LICENSE).


### PR DESCRIPTION
Adds a refrence to the project license to README.md. This is considered a best-practice.